### PR TITLE
fix vertical wall mode context menu artwork

### DIFF
--- a/1080i/Views_Row.xml
+++ b/1080i/Views_Row.xml
@@ -208,6 +208,7 @@
             <visible>Control.IsVisible($PARAM[id]4)</visible>
             <include content="$PARAM[include]">
                 <param name="id" value="$PARAM[id]4" />
+                <param name="context_button" value="$PARAM[context_button]" />
                 <preloaditems>2</preloaditems>
                 <bottom>1</bottom>
                 <onback>ClearProperty(WallMode)</onback>
@@ -338,6 +339,7 @@
         <include content="View_Row_WallSwitch">
             <param name="id" value="$PARAM[id]" />
             <param name="include" value="$PARAM[wall_include]" />
+            <param name="context_button" value="true" />
         </include>
     </include>
 </includes>


### PR DESCRIPTION
Hi! When using local artwork the context menu images (poster/fanart) in vertical wall mode do not refresh, the skin is always using the item that was selected before entering vertical mode.

Hope this helps, feel free to decline :) 