### PR TITLE
Show correct shuffle icon in Music OSD display / Load ArtistSlideshow

### DIFF
--- a/1080i/Images.xml
+++ b/1080i/Images.xml
@@ -34,8 +34,8 @@
     </variable>
 
     <variable name="Image_OSD_Shuffle">
-        <value condition="Playlist.IsRandom">osd/shuffle.png</value>
-        <value>osd/shuffle-on.png</value>
+        <value condition="Playlist.IsRandom">osd/shuffle-on.png</value>
+        <value>osd/shuffle.png</value>
     </variable>
 
     <variable name="Image_UpNext">

--- a/1080i/MusicVisualisation.xml
+++ b/1080i/MusicVisualisation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-    <!-- <onload condition="System.HasAddon(script.artistslideshow)">RunScript(script.artistslideshow)</onload> -->
+    <onload condition="System.HasAddon(script.artistslideshow)">RunScript(script.artistslideshow)</onload>
     <include>Animation_FadeIn</include>
     <include>Animation_FadeOut</include>
     <controls>


### PR DESCRIPTION
For variable Image_OSD_Shuffle, the textures were reversed from the correct usage (eg shuffle_on.png was used when the playlist was not random)