### PR TITLE
Change the way duration and endtimes display in Info Bar

### DIFF
--- a/1080i/Info.xml
+++ b/1080i/Info.xml
@@ -258,16 +258,41 @@
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
 
+                    <!-- Duration Info -->
                     <include content="Info_Line_Label" condition="!$PARAM[player]">
                         <param name="controltype" value="$PARAM[controltype]" />
                         <param name="label" value="$INFO[$PARAM[container]ListItem.Duration(h),, $LOCALIZE[31074] ]$INFO[$PARAM[container]ListItem.Duration(m),, $LOCALIZE[31073]]" />
-                        <param name="visible" value="!String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml)" />
+                        <param name="visible" value="!String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + !String.IsEqual($PARAM[container]ListItem.Duration(h), 0)" />
+                        <param name="textcolor" value="$PARAM[colordiffuse]_90" />
+                    </include>
+                    <include content="Info_Line_Label" condition="!$PARAM[player]">
+                        <param name="controltype" value="$PARAM[controltype]" />
+                        <param name="label" value="$INFO[$PARAM[container]ListItem.Duration(m),, $LOCALIZE[31073]]" />
+                        <param name="visible" value="!String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + String.IsEqual($PARAM[container]ListItem.Duration(h), 0)" />
+                        <param name="textcolor" value="$PARAM[colordiffuse]_90" />
+                    </include>
+                    <include content="Info_Line_Label" condition="!$PARAM[player]">
+                        <param name="controltype" value="$PARAM[controltype]" />
+                        <param name="label" value="$INFO[$PARAM[container]ListItem.Duration(h),, $LOCALIZE[31074]]" />
+                        <param name="visible" value="!String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + String.IsEqual($PARAM[container]ListItem.Duration(m), 0)" />
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
                     <include content="Info_Line_Label" condition="!$PARAM[player]">
                         <param name="controltype" value="$PARAM[controltype]" />
                         <param name="label" value="$INFO[Window(Home).Property(TMDbHelper.ListItem.Duration_H),, $LOCALIZE[31074] ]$INFO[Window(Home).Property(TMDbHelper.ListItem.Duration_M),, $LOCALIZE[31073]]" />
-                        <param name="visible" value="String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Duration)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration),0) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml)" />
+                        <param name="visible" value="String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Duration)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration),0) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration_H), 0)" />
+                        <param name="textcolor" value="$PARAM[colordiffuse]_90" />
+                    </include>
+                    <include content="Info_Line_Label" condition="!$PARAM[player]">
+                        <param name="controltype" value="$PARAM[controltype]" />
+                        <param name="label" value="$INFO[Window(Home).Property(TMDbHelper.ListItem.Duration_M),, $LOCALIZE[31073]]" />
+                        <param name="visible" value="String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Duration)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration),0) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration_H), 0)" />
+                        <param name="textcolor" value="$PARAM[colordiffuse]_90" />
+                    </include>
+                    <include content="Info_Line_Label" condition="!$PARAM[player]">
+                        <param name="controltype" value="$PARAM[controltype]" />
+                        <param name="label" value="$INFO[Window(Home).Property(TMDbHelper.ListItem.Duration_H),, $LOCALIZE[31074]]" />
+                        <param name="visible" value="String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Duration)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration),0) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration_M), 0)" />
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
                     <include content="Info_Line_Label" condition="!$PARAM[player] + Skin.HasSetting(InfoLine.EndTime)">

--- a/1080i/Info.xml
+++ b/1080i/Info.xml
@@ -262,7 +262,7 @@
                     <include content="Info_Line_Label" condition="!$PARAM[player]">
                         <param name="controltype" value="$PARAM[controltype]" />
                         <param name="label" value="$INFO[$PARAM[container]ListItem.Duration(h),, $LOCALIZE[31074] ]$INFO[$PARAM[container]ListItem.Duration(m),, $LOCALIZE[31073]]" />
-                        <param name="visible" value="!String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + !String.IsEqual($PARAM[container]ListItem.Duration(h), 0)" />
+                        <param name="visible" value="!String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + !String.IsEqual($PARAM[container]ListItem.Duration(h), 0) + !String.IsEqual($PARAM[container]ListItem.Duration(m), 0)" />
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
                     <include content="Info_Line_Label" condition="!$PARAM[player]">
@@ -280,7 +280,7 @@
                     <include content="Info_Line_Label" condition="!$PARAM[player]">
                         <param name="controltype" value="$PARAM[controltype]" />
                         <param name="label" value="$INFO[Window(Home).Property(TMDbHelper.ListItem.Duration_H),, $LOCALIZE[31074] ]$INFO[Window(Home).Property(TMDbHelper.ListItem.Duration_M),, $LOCALIZE[31073]]" />
-                        <param name="visible" value="String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Duration)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration),0) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration_H), 0)" />
+                        <param name="visible" value="String.IsEmpty($PARAM[container]ListItem.Duration) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Duration)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration),0) + !String.IsEqual(ListItem.DBType,artist) + !String.IsEqual(ListItem.DBType,album) + !String.IsEqual(ListItem.DBType,song) + !Window.IsVisible(MyPVRGuide.xml) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration_H), 0) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.Duration_M), 0)" />
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
                     <include content="Info_Line_Label" condition="!$PARAM[player]">

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -415,14 +415,6 @@
                                 <onclick>Skin.ToggleSetting(TMDbHelper.DisablePVR)</onclick>
                                 <selected>!Skin.HasSetting(TMDbHelper.DisablePVR)</selected>
                             </include>
-                            <include content="Dialog_Settings_Button" description="Display End Times">
-                                <param name="id" value="7007" />
-                                <param name="control" value="radiobutton" />
-                                <label>$LOCALIZE[31267]</label>
-                                <visible>Container(3).HasFocus(7)</visible>
-                                <onclick>Skin.ToggleSetting(InfoLine.EndTime)</onclick>
-                                <selected>Skin.HasSetting(InfoLine.EndTime)</selected>
-                            </include>
                             <include content="Dialog_Settings_Button" description="CustomDialog Indicators">
                                 <param name="id" value="7006" />
                                 <label>$LOCALIZE[31234]</label>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -407,6 +407,14 @@
                                 <onclick>Skin.ToggleSetting(TMDbHelper.DisablePVR)</onclick>
                                 <selected>!Skin.HasSetting(TMDbHelper.DisablePVR)</selected>
                             </include>
+                            <include content="Dialog_Settings_Button" description="Display End Times">
+                                <param name="id" value="7007" />
+                                <param name="control" value="radiobutton" />
+                                <label>$LOCALIZE[31266]</label>
+                                <visible>Container(3).HasFocus(7)</visible>
+                                <onclick>Skin.ToggleSetting(InfoLine.EndTime)</onclick>
+                                <selected>Skin.HasSetting(InfoLine.EndTime)</selected>
+                            </include>
                             <include content="Dialog_Settings_Button" description="CustomDialog Indicators">
                                 <param name="id" value="7006" />
                                 <label>$LOCALIZE[31234]</label>
@@ -433,7 +441,7 @@
                             </include>
 
 
-                            <!-- Playback -->
+                            <!-- Dependencies -->
                             <include content="Dialog_Settings_Label" description="Dependencies">
                                 <param name="id" value="8000" />
                                 <label>$LOCALIZE[39024]</label>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1344,8 +1344,3 @@ msgstr ""
 msgctxt "#31266"
 msgid "Pause video when opening info"
 msgstr ""
-
-#: /1080i/SkinSettings.xml
-msgctxt "#31267"
-msgid "Show endtimes in infobar"
-msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1339,3 +1339,8 @@ msgstr ""
 msgctxt "#31265"
 msgid "Budget"
 msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31266"
+msgid "Show endtimes in infobar"
+msgstr ""


### PR DESCRIPTION
As asked for in #365 remove the hour part if less than an hour. So instead of 0 hr 30 mins, it displays 30 mins. Also, if the minutes is 0. So instead of 2 hr 0 mins, it displays 2 hr.
Also creates a setting to toggle end time display, as this setting is referenced in Info.xml, but didn't exist.