### PR TITLE
Fix display of air date in player for episodes

### DIFF
--- a/1080i/Info.xml
+++ b/1080i/Info.xml
@@ -184,13 +184,13 @@
                     <include content="Info_Line_Label" condition="$PARAM[player]">
                         <param name="controltype" value="$PARAM[controltype]" />
                         <param name="label" value="$INFO[VideoPlayer.Year]" />
-                        <param name="visible" value="!String.IsEmpty(VideoPlayer.Year) + [!String.IsEqual(VideoPlayer.DBType,episode) | String.IsEmpty(VideoPlayer.Premiered)]" />
+                        <param name="visible" value="!String.IsEmpty(VideoPlayer.Year) + [String.IsEmpty(VideoPlayer.Episode) | String.IsEmpty(VideoPlayer.Premiered)]" />
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
                     <include content="Info_Line_Label" condition="$PARAM[player]">
                         <param name="controltype" value="$PARAM[controltype]" />
                         <param name="label" value="$INFO[VideoPlayer.Premiered]" />
-                        <param name="visible" value="!String.IsEmpty(VideoPlayer.Premiered) + String.IsEqual(VideoPlayer.DBType,episode)" />
+                        <param name="visible" value="!String.IsEmpty(VideoPlayer.Premiered) + !String.IsEmpty(VideoPlayer.Episode)" />
                         <param name="textcolor" value="$PARAM[colordiffuse]_90" />
                     </include>
                     <include content="Info_Line_Label" condition="$PARAM[player]">


### PR DESCRIPTION
The date in the player was only showing the year for the episode date, even though the premier date was available.
This was due to a call to VideoPlayer.DBType, which would always return false, as it doesn't seem to be in the Kodi InfoLabels.
I changed it so it displays if there is an episode number for the currently playing item.