### PR TITLE
Let plotboxes in OSD Episode List scroll

### DIFF
--- a/1080i/Layouts.xml
+++ b/1080i/Layouts.xml
@@ -1341,7 +1341,7 @@
                         </include>
                         <include content="Object_Control">
                             <param name="control" value="textbox" />
-                            <autoscroll>false</autoscroll>
+                            <autoscroll delay="6000" time="3000" repeat="10000">!Skin.HasSetting(Textboxes.DisableAutoscroll)</autoscroll>
                             <include content="Object_Include" condition="$PARAM[selected]">
                                 <textcolor>panel_fg_90</textcolor>
                                 <selectedcolor>panel_fg_90</selectedcolor>
@@ -1351,7 +1351,7 @@
                                 <selectedcolor>dialog_fg_70</selectedcolor>
                             </include>
                             <label fallback="31159">$INFO[ListItem.Plot]</label>
-                            <font>font_plotbox</font>
+                            <font>font_plotbox_mini</font>
                             <top>40</top>
                             <bottom>40</bottom>
                             <aligny>center</aligny>

--- a/1080i/Layouts.xml
+++ b/1080i/Layouts.xml
@@ -1341,7 +1341,6 @@
                         </include>
                         <include content="Object_Control">
                             <param name="control" value="textbox" />
-                            <autoscroll delay="6000" time="3000" repeat="10000">!Skin.HasSetting(Textboxes.DisableAutoscroll)</autoscroll>
                             <include content="Object_Include" condition="$PARAM[selected]">
                                 <textcolor>panel_fg_90</textcolor>
                                 <selectedcolor>panel_fg_90</selectedcolor>


### PR DESCRIPTION
Fixes #364. 

Set the scroll time to the same as the default for plotboxes.
Reduce font size of plot so it doesn't look oversized.