### PR TITLE
Use Video Library and Music Library as Headers

### DIFF
--- a/1080i/Labels.xml
+++ b/1080i/Labels.xml
@@ -237,7 +237,7 @@
         <value condition="!String.IsEmpty(Container.FolderName)">$INFO[Container.FolderName]</value>
         <value condition="Window.IsVisible(MyPVRGuide.xml)">$LOCALIZE[19069]</value>
         <value condition="Window.IsVisible(10025)">$LOCALIZE[14236]</value>
-		<value condition="Window.IsVisible(10502)">$LOCALIZE[14237]</value>
+        <value condition="Window.IsVisible(10502)">$LOCALIZE[14237]</value>
         <value>$LOCALIZE[10000]</value>
     </variable>
 


### PR DESCRIPTION
When selecting the Video Library or Music Library from the Home page, the header in the left hand corner shows "Home". This PR displays the correct Library title