### PR TITLE
Option to set widget content to selected favourite

### DIFF
--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -258,7 +258,10 @@
                 <shortcut widget="MusicSources" label="$LOCALIZE[31100]" icon="DefaultMusicSongs.png" widgetTarget="music" type="music">sources://music/</shortcut>
                 <shortcut widget="PictureSources" label="$LOCALIZE[31101]" icon="DefaultPicture.png" widgetTarget="pictures" type="pictures">sources://pictures/</shortcut>
             </node>
-            <shortcut widget="Favourites" label="$LOCALIZE[1036]" widgetTarget="">favourites://</shortcut>
+            <node label="$LOCALIZE[32006]">
+                <shortcut widget="Favourites" label="$LOCALIZE[1036]" icon="DefaultFavourites.png" widgetTarget="">favourites://</shortcut>
+                <content>favourite</content>
+            </node>
             <shortcut widget="Submenu" label="$LOCALIZE[1034]">Submenu</shortcut>
             <shortcut widget="Fullscreen" label="$LOCALIZE[35232]">Fullscreen</shortcut>
         </node>


### PR DESCRIPTION
I often save channels/folders/categories from video addons to favourites so that I can easily access them later.

It would be helpful to be able to easily create widgets from a particular saved favourites, rather than just a widget showing all favourites.