### PR TITLE
Add option to open power menu from up on home menu

### DIFF
--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -214,7 +214,9 @@
                 <onfocus>ClearProperty(OptionsMenuFocused,Home)</onfocus>
                 <onfocus>SetProperty(TMDbHelper.WidgetContainer,301,Home)</onfocus>
 
-                <onup condition="!Skin.HasSetting(DisableSubmenuOnUp)">SetFocus(302,0,absolute)</onup>
+                <onup condition="Skin.String(HomeMenu.OnUp,Submenu)">SetFocus(302,0,absolute)</onup>
+                <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetProperty(OptionsMenuFocused,303,Home)</onup>
+                <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetFocus(303)</onup>
                 <oninfo>SetFocus(302,0,absolute)</oninfo>
                 <onclick>SetProperty(MenuSelect,1)</onclick>
                 <onclick>SetFocus(300)</onclick>
@@ -244,7 +246,9 @@
                 </include>
                 <include>skinshortcuts-template-menubar</include>
                 <onfocus>ClearProperty(OptionsMenuFocused,Home)</onfocus>
-                <onup condition="!Skin.HasSetting(DisableSubmenuOnUp)">SetFocus(302,0,absolute)</onup>
+                <onup condition="Skin.String(HomeMenu.OnUp,Submenu)">SetFocus(302,0,absolute)</onup>
+                <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetProperty(OptionsMenuFocused,303,Home)</onup>
+                <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetFocus(303)</onup>
                 <oninfo>SetFocus(302,0,absolute)</oninfo>
                 <onright>SetProperty(OptionsMenuFocused,303,Home)</onright>
                 <onright>SetFocus(303)</onright>

--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -214,7 +214,7 @@
                 <onfocus>ClearProperty(OptionsMenuFocused,Home)</onfocus>
                 <onfocus>SetProperty(TMDbHelper.WidgetContainer,301,Home)</onfocus>
 
-                <onup condition="Skin.String(HomeMenu.OnUp,Submenu)">SetFocus(302,0,absolute)</onup>
+                <onup condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">SetFocus(302,0,absolute)</onup>
                 <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetProperty(OptionsMenuFocused,303,Home)</onup>
                 <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetFocus(303)</onup>
                 <oninfo>SetFocus(302,0,absolute)</oninfo>
@@ -246,7 +246,7 @@
                 </include>
                 <include>skinshortcuts-template-menubar</include>
                 <onfocus>ClearProperty(OptionsMenuFocused,Home)</onfocus>
-                <onup condition="Skin.String(HomeMenu.OnUp,Submenu)">SetFocus(302,0,absolute)</onup>
+                <onup condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">SetFocus(302,0,absolute)</onup>
                 <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetProperty(OptionsMenuFocused,303,Home)</onup>
                 <onup condition="Skin.String(HomeMenu.OnUp,PowerMenu)">SetFocus(303)</onup>
                 <oninfo>SetFocus(302,0,absolute)</oninfo>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -32,9 +32,9 @@
     </variable>
 
     <variable name="Label_Setting_HomeMenuUp">
-        <value condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">$LOCALIZE[31289]</value>
-        <value condition="Skin.String(HomeMenu.OnUp,Submenu)">$LOCALIZE[31290]</value>
-        <value condition="Skin.String(HomeMenu.OnUp,PowerMenu)">$LOCALIZE[31291]</value>
+        <value condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">$LOCALIZE[31290]</value>
+        <value condition="Skin.String(HomeMenu.OnUp,Submenu)">$LOCALIZE[31291]</value>
+        <value condition="Skin.String(HomeMenu.OnUp,PowerMenu)">$LOCALIZE[31292]</value>
     </variable>
 
     <variable name="Label_Setting_RowScrollBar">

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -31,6 +31,12 @@
         <value condition="$EXP[Exp_IsPVRItem] + !String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]</value>
     </variable>
 
+    <variable name="Label_Setting_HomeMenuUp">
+        <value condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">$LOCALIZE[31289]</value>
+        <value condition="Skin.String(HomeMenu.OnUp,Submenu)">$LOCALIZE[31290]</value>
+        <value condition="Skin.String(HomeMenu.OnUp,PowerMenu)">$LOCALIZE[31291]</value>
+    </variable>
+
     <variable name="Label_Setting_RowScrollBar">
         <value condition="Skin.String(Rows.OnDown,Wall)">$LOCALIZE[31184]</value>
         <value>$LOCALIZE[31018]</value>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -33,8 +33,8 @@
 
     <variable name="Label_Setting_HomeMenuUp">
         <value condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">$LOCALIZE[31290]</value>
-        <value condition="Skin.String(HomeMenu.OnUp,Submenu)">$LOCALIZE[31291]</value>
-        <value condition="Skin.String(HomeMenu.OnUp,PowerMenu)">$LOCALIZE[31292]</value>
+        <value condition="Skin.String(HomeMenu.OnUp,PowerMenu)">$LOCALIZE[31291]</value>
+        <value condition="Skin.String(HomeMenu.OnUp,None)">$LOCALIZE[31292]</value>
     </variable>
 
     <variable name="Label_Setting_RowScrollBar">

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -236,9 +236,9 @@
                                 <label>$LOCALIZE[31179]</label>
                                 <label2>$VAR[Label_Setting_HomeMenuUp]</label2>
                                 <visible>Container(3).HasFocus(3)</visible>
-                                <onclick condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">Skin.SetString(HomeMenu.OnUp,Submenu)</onclick>
-                                <onclick condition="Skin.String(HomeMenu.OnUp,Submenu)">Skin.SetString(HomeMenu.OnUp,PowerMenu)</onclick>
-                                <onclick condition="Skin.String(HomeMenu.OnUp,PowerMenu)">Skin.Reset(HomeMenu.OnUp)</onclick>
+                                <onclick condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">Skin.SetString(HomeMenu.OnUp,PowerMenu)</onclick>
+                                <onclick condition="Skin.String(HomeMenu.OnUp,PowerMenu)">Skin.SetString(HomeMenu.OnUp,None)</onclick>
+                                <onclick condition="Skin.String(HomeMenu.OnUp,None)">Skin.Reset(HomeMenu.OnUp)</onclick>
                             </include>
                             <include content="Dialog_Settings_Button" description="Pressing Down from Scrollbar">
                                 <param name="id" value="3003" />

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -230,13 +230,15 @@
                                 <onclick>Skin.ToggleSetting(PVR.DisableOnBackMenu)</onclick>
                                 <selected>!Skin.HasSetting(PVR.DisableOnBackMenu)</selected>
                             </include>
-                            <include content="Dialog_Settings_Button" description="Pressing Up opens Submenu">
+                            <include content="Dialog_Settings_Button" description="Pressing Up from HomeMenu">
                                 <param name="id" value="3002" />
-                                <param name="control" value="radiobutton" />
+                                <param name="control" value="button" />
                                 <label>$LOCALIZE[31179]</label>
+                                <label2>$VAR[Label_Setting_HomeMenuUp]</label2>
                                 <visible>Container(3).HasFocus(3)</visible>
-                                <onclick>Skin.ToggleSetting(DisableSubmenuOnUp)</onclick>
-                                <selected>!Skin.HasSetting(DisableSubmenuOnUp)</selected>
+                                <onclick condition="String.IsEmpty(Skin.String(HomeMenu.OnUp))">Skin.SetString(HomeMenu.OnUp,Submenu)</onclick>
+                                <onclick condition="Skin.String(HomeMenu.OnUp,Submenu)">Skin.SetString(HomeMenu.OnUp,PowerMenu)</onclick>
+                                <onclick condition="Skin.String(HomeMenu.OnUp,PowerMenu)">Skin.Reset(HomeMenu.OnUp)</onclick>
                             </include>
                             <include content="Dialog_Settings_Button" description="Pressing Down from Scrollbar">
                                 <param name="id" value="3003" />

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -907,7 +907,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31179"
-msgid "Press up from home menu to open submenu"
+msgid "Press up from home menu"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -1453,4 +1453,19 @@ msgstr ""
 #: /1080i/Includes_Items.xml
 msgctxt "#31288"
 msgid "Use larger flixart size"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31289"
+msgid "Stay on home menu"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31290"
+msgid "Open submenu"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31291"
+msgid "Open power menu"
 msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1462,15 +1462,15 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31290"
-msgid "Stay on home menu"
-msgstr ""
-
-#: /1080i/Includes_Labels.xml
-msgctxt "#31291"
 msgid "Open submenu"
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
-msgctxt "#31292"
+msgctxt "#31291"
 msgid "Open power menu"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31292"
+msgid "Do nothing"
 msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -907,7 +907,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31179"
-msgid "Press up from home menu to open submenu"
+msgid "Press up from home menu"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -1458,4 +1458,19 @@ msgstr ""
 #: /1080i/Includes_Items.xml
 msgctxt "#31289"
 msgid "Use local library info for recommendations"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31290"
+msgid "Stay on home menu"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31291"
+msgid "Open submenu"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31292"
+msgid "Open power menu"
 msgstr ""


### PR DESCRIPTION
For consideration.

I use the power menu for common tasks/commands (open favourites, video playlists, refresh library, open addons) that don't really fit into any individual home menu submenu.

I have configured the home menu onclick action to open the submenu. This PR adds a navigation option to open the power menu, rather than the submenu, when pressing up on the home menu, saving me a few clicks.