### PR TITLE
Fix for Collection display when using "Use local library info for recommendations"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 *~
 Thumbs.db
 *.sublime-snippet
-.project

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 Thumbs.db
 *.sublime-snippet
+.project

--- a/1080i/Includes_DialogInfo.xml
+++ b/1080i/Includes_DialogInfo.xml
@@ -527,7 +527,7 @@
                 <onback>SetFocus(5000)</onback>
             </include>
 
-            <include content="Widget_Poster" condition="!$EXP[Exp_IsPersonInfo] + [[!Skin.HasSetting(Info.DisableCollections) + !String.IsEqual(ListItem.DBType,tvshow)] | [!Skin.HasSetting(Info.DisableSeasons) + String.IsEqual(ListItem.DBType,tvshow)]]">
+            <include content="Widget_Poster" condition="!String.IsEmpty(ListItem.SetID) + !$EXP[Exp_IsPersonInfo] + [[!Skin.HasSetting(Info.DisableCollections) + !String.IsEqual(ListItem.DBType,tvshow)] | [!Skin.HasSetting(Info.DisableSeasons) + String.IsEqual(ListItem.DBType,tvshow)]]">
                 <param name="groupid" value="6300" />
                 <param name="id" value="6200" />
                 <param name="label" value="$LOCALIZE[31108]" />


### PR DESCRIPTION
When using "Use local library info for recommendations" under Customize Recommendations, and then viewing a Movie that has a collection setup it works. But then navigate to another movie that does not have collections, and the previous movies collections would display.

My fix seems to work, but maybe the real fix is elsewhere?