### PR TITLE
Proposed improvements for info title rendering.

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -25,23 +25,23 @@
         <font>
             <name>font_info_black</name>
             <filename>RobotoCondensed-Black.ttf</filename>
-            <size>112</size>
+            <size>97</size>
         </font>
         <font>
             <name>font_info_light</name>
             <filename>RobotoCondensed-Light.ttf</filename>
-            <size>112</size>
+            <size>97</size>
         </font>
         <font>
             <name>font_info_black_doublerow</name>
             <filename>RobotoCondensed-Black.ttf</filename>
-            <size>56</size>
+            <size>64</size>
             <linespacing>0.9</linespacing>
         </font>
         <font>
             <name>font_info_light_doublerow</name>
             <filename>RobotoCondensed-Light.ttf</filename>
-            <size>56</size>
+            <size>64</size>
             <linespacing>0.9</linespacing>
         </font>
 

--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -71,20 +71,22 @@
                 <width>info_plot_w</width>
                 <control type="label">
                     <aligny>center</aligny>
-                    <height>114</height>
-                    <top>0</top>
+                    <height>120</height>
+                    <top>-4</top>
                     <label>$PARAM[label]</label>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
+                    <shadowcolor>55000000</shadowcolor>
                     <font>$PARAM[font]</font>
                     <visible>Integer.IsEqual(Container(99991).NumPages,1)</visible>
                 </control>
                 <control type="label">
                     <wrapmultiline>true</wrapmultiline>
                     <aligny>center</aligny>
-                    <height>114</height>
-                    <top>0</top>
+                    <height>120</height>
+                    <top>-24</top>
                     <label>$PARAM[label]</label>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
+                    <shadowcolor>55000000</shadowcolor>
                     <font>$PARAM[font]_doublerow</font>
                     <width>50%</width>
                     <visible>!Integer.IsEqual(Container(99991).NumPages,1)</visible>
@@ -93,10 +95,11 @@
                 <control type="label">
                     <wrapmultiline>true</wrapmultiline>
                     <aligny>center</aligny>
-                    <height>114</height>
-                    <top>0</top>
+                    <height>120</height>
+                    <top>-24</top>
                     <label>$PARAM[label]</label>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
+                    <shadowcolor>55000000</shadowcolor>
                     <font>$PARAM[font]_doublerow</font>
                     <width>70%</width>
                     <visible>!Integer.IsEqual(Container(99991).NumPages,1)</visible>
@@ -106,10 +109,11 @@
                 <control type="label">
                     <wrapmultiline>true</wrapmultiline>
                     <aligny>center</aligny>
-                    <height>114</height>
-                    <top>0</top>
+                    <height>120</height>
+                    <top>-24</top>
                     <label>$PARAM[label]</label>
                     <textcolor>$PARAM[colordiffuse]_100</textcolor>
+                    <shadowcolor>55000000</shadowcolor>
                     <font>$PARAM[font]_doublerow</font>
                     <visible>!Integer.IsEqual(Container(99991).NumPages,1)</visible>
                     <visible>!Integer.IsEqual(Container(99992).NumPages,1)</visible>


### PR DESCRIPTION
As I mentioned in the comments for https://github.com/jurialmunkey/skin.arctic.horizon.2/issues/682, here are my proposed changes to the info title element in an effort to make the double line presentation more prominent. The code itself is a bit of a hack giving negative top locations, but it works. 

Here are the justifications --
1. Font sizes align with the existing Pentatonic scale.
2. Slightly smaller info_titles allow more space before wrapping occurs. Cases, where titles wrap, drop drastically and when they do, it's a reasonable decision in testing against my library.  
3. Increased the line spacing so the distance of the info_title baseline and the top of the info line matches the spacing between the info line and the ratings. Allows letter ascenders and descenders more space to reduce the "cramped" feeling.
4. Though the tops of the single and double titles don't align, their baselines do. Affects Info screen rendering slightly, but because you aren't seeing different titles displayed in rapid succession while in the info screen, it's a good tradeoff.
5. Added standard, WCAG-type 3:1 drop shadow to info_titles to increase the prominence and improve readability when fanart impacts the text contrast ratio.

The bottom line is that it's a matter of artistic preference, but give it a try for a bit. I'm so used to it that I can't go back to the old presentation. I've been running the changes for the past month so it's pretty well tested against my library. I've seen no issues with the 64/97 ratio in terms of functional calculation. 

Composite image showing new info_title alignment.
![Untitled-1](https://user-images.githubusercontent.com/4211774/205721201-4aa2be37-3ec0-4ac4-a939-87095ad308e6.png)

