### PR TITLE
Allow colorbutton to be used in addon settings

### DIFF
--- a/1080i/DialogAddonSettings.xml
+++ b/1080i/DialogAddonSettings.xml
@@ -147,5 +147,11 @@
             <param name="control" value="label" />
             <description>Default Setting Label</description>
         </include>
+
+        <include content="Dialog_Settings_Button">
+            <param name="id" value="15" />
+            <param name="control" value="colorbutton" />
+            <description>Default Setting Button</description>
+        </include>
     </controls>
 </window>


### PR DESCRIPTION
As mentioned [here](https://github.com/jurialmunkey/skin.arctic.horizon.2/issues/681#issuecomment-1378821395), small addition following on from [b8618aa](https://github.com/jurialmunkey/skin.arctic.horizon.2/commit/b8618aa3716c3c870c248ec0bab95ae3f4aac79b)

Addresses #743 