### PR TITLE
Fix for missing timer icon on in-progress episodes

### DIFF
--- a/1080i/script-skinvariables-includes.xml
+++ b/1080i/script-skinvariables-includes.xml
@@ -548,7 +548,7 @@
         <value condition="True">$INFO[ListItem.Icon]</value>
     </variable>
     <variable name="Image_Overlay_C50">
-        <value condition="[String.IsEqual(Container(50).ListItem.DBType,tvshow) | String.IsEqual(Container(50).ListItem.DBType,season) | String.IsEqual(Container(50).ListItem.DBType,episode)] + !Integer.IsEqual(Container(50).ListItem.Property(UnWatchedEpisodes),0) + !Skin.HasSetting(Indicator.DisableEpisodes)">common/null.png</value>
+        <value condition="[String.IsEqual(Container(50).ListItem.DBType,tvshow) | String.IsEqual(Container(50).ListItem.DBType,season) | String.IsEqual(Container(50).ListItem.DBType,episode)] + !Integer.IsEqual(Container(50).ListItem.Property(UnWatchedEpisodes),0) + !Container(50).ListItem.IsResumable + !Skin.HasSetting(Indicator.DisableEpisodes)">common/null.png</value>
         <value condition="Container(50).ListItem.IsRecording">indicator/record.png</value>
         <value condition="Container(50).ListItem.HasTimer">indicator/timer.png</value>
         <value condition="Container(50).ListItem.IsResumable + !Skin.HasSetting(Indicator.DisableProgress)">indicator/timer.png</value>
@@ -567,7 +567,7 @@
         <value condition="Window.IsVisible(AddonBrowser.xml) + Container(50).ListItem.Property(addon.isinstalled)">indicator/library.png</value>
     </variable>
     <variable name="Image_Overlay">
-        <value condition="[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)] + !Integer.IsEqual(ListItem.Property(UnWatchedEpisodes),0) + !Skin.HasSetting(Indicator.DisableEpisodes)">common/null.png</value>
+        <value condition="[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)] + !Integer.IsEqual(ListItem.Property(UnWatchedEpisodes),0) + !ListItem.IsResumable + !Skin.HasSetting(Indicator.DisableEpisodes)">common/null.png</value>
         <value condition="ListItem.IsRecording">indicator/record.png</value>
         <value condition="ListItem.HasTimer">indicator/timer.png</value>
         <value condition="ListItem.IsResumable + !Skin.HasSetting(Indicator.DisableProgress)">indicator/timer.png</value>

--- a/shortcuts/skinvariables.xml
+++ b/shortcuts/skinvariables.xml
@@ -184,7 +184,7 @@
     <variable name="Image_Overlay" containers="50">
 
         <!-- Unwatched Episodes -->
-        <value condition="[String.IsEqual({listitemposition}.DBType,tvshow) | String.IsEqual({listitemposition}.DBType,season) | String.IsEqual({listitemposition}.DBType,episode)] + !Integer.IsEqual({listitemposition}.Property(UnWatchedEpisodes),0) + !Skin.HasSetting(Indicator.DisableEpisodes)">common/null.png</value>
+        <value condition="[String.IsEqual({listitemposition}.DBType,tvshow) | String.IsEqual({listitemposition}.DBType,season) | String.IsEqual({listitemposition}.DBType,episode)] + !Integer.IsEqual({listitemposition}.Property(UnWatchedEpisodes),0) + !{listitemposition}.IsResumable + !Skin.HasSetting(Indicator.DisableEpisodes)">common/null.png</value>
 		
         <!-- PVR Timers / Recording -->
         <value condition="{listitemposition}.IsRecording">indicator/record.png</value>


### PR DESCRIPTION
#728 and 2716878 introduced a bug where the timer icon for in-progress episodes was not being shown because the variable condition used for items with unwatched episodes is a higher priority than the condition for resumable items.

This PR simply checks that the TV Show/Season/Episode with unwatched episodes is not also resumable.

Before:
![image](https://user-images.githubusercontent.com/56883549/233049969-2c88d5c8-c981-4c48-9a6c-f8776d2c406e.png)

After:
![image](https://user-images.githubusercontent.com/56883549/233050675-7acac69b-dbad-44a9-9416-7c26ef77388b.png)
