### PR TITLE
Fix fullscreen video OSD HdrType null

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -30,9 +30,9 @@
     </variable>
 
     <variable name="Image_OSD_HDR_Codec">
-        <value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">other/dolbyvision.png</value>
-        <value condition="String.IsEqual(ListItem.HdrType,hdr10)">other/hdr10.png</value>
-        <value condition="String.IsEqual(ListItem.HdrType,hlg)">other/hlg.png</value>
+        <value condition="String.IsEqual(VideoPlayer.HdrType,dolbyvision)">other/dolbyvision.png</value>
+        <value condition="String.IsEqual(VideoPlayer.HdrType,hdr10)">other/hdr10.png</value>
+        <value condition="String.IsEqual(VideoPlayer.HdrType,hlg)">other/hlg.png</value>
         <value>other/HDR.png</value>
     </variable>
 


### PR DESCRIPTION
When viewing OSD information in full-screen video, the value of ListItem.HdrType is null, causing the default HDR.png to be used and changed to VideoPlayer.HdrType to solve this problem.