### PR TITLE
Add GameOSD.xml based on shutdown menu

### DIFF
--- a/1080i/GameOSD.xml
+++ b/1080i/GameOSD.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<window type="dialog">
+    <defaultcontrol always="true">9000</defaultcontrol>
+    <controls>
+
+        <include content="Object_Options_Menu">
+            <param name="grouplist_items" value="Items_GameOSD_Settings" />
+            <param name="isbuttonmenu" value="true" />
+            <param name="isfocused" value="true" />
+            <param name="action_include" value="Action_OptionsMenu_ButtonMenu" />
+        </include>
+
+    </controls>
+</window>

--- a/1080i/Includes_Items.xml
+++ b/1080i/Includes_Items.xml
@@ -2457,4 +2457,61 @@
         </include>
     </include>
 
+    <include name="Items_GameOSD_Settings">
+        <include content="Dialog_Settings_Button" description="Pause / Resume button">
+            <param name="id" value="101" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35224]</label>
+            <onclick>Play</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Reset button">
+            <param name="id" value="102" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[13007]</label>
+            <onclick>PlayerControl(Reset)</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Stop button">
+            <param name="id" value="103" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35222]</label>
+            <onclick>Stop</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Game Video Filter button">
+            <param name="id" value="104" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35225]</label>
+            <onclick>ActivateWindow(GameVideoFilter)</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Game Stretch Mode button">
+            <param name="id" value="105" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35233]</label>
+            <onclick>ActivateWindow(GameStretchMode)</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Game Video Rotation button">
+            <param name="id" value="106" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35227]</label>
+            <onclick>ActivateWindow(GameVideoRotation)</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Game Volume button">
+            <param name="id" value="107" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[13376]</label>
+            <onclick>ActivateWindow(GameVolume)</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Game Controllers button">
+            <param name="id" value="109" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35234]</label>
+            <onclick>ActivateWindow(GameControllers)</onclick>
+        </include>
+        <include content="Dialog_Settings_Button" description="Game Advanced Settings button">
+            <param name="id" value="110" />
+            <param name="control" value="button" />
+            <label>$LOCALIZE[35226]</label>
+            <onclick>ActivateWindow(GameAdvancedSettings)</onclick>
+        </include>
+    </include>
+
 </includes>


### PR DESCRIPTION
I thought the functionality was broken, but the log mentioned `GameOSD.xml` to be missing.
Not a skinner at all, but with some information I found I could make it work using this.
Let me know if there is a better way to do this.

Screenshot of it in action:
![screenshot00007](https://github.com/jurialmunkey/skin.arctic.horizon.2/assets/1552365/5b346a92-5f62-42e1-95c1-9c5b4e7a60e1)
