### PR TITLE
Update addon.xml for Omega XBMC GUI Version

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,6 @@
 <addon id="skin.arctic.horizon.2" name="Arctic Horizon 2" provider-name="jurialmunkey" version="0.8.29">
     <requires>
-        <import addon="xbmc.gui" version="5.16.0" />
+        <import addon="xbmc.gui" version="5.17.0" />
         <import addon="script.skinshortcuts" version="0.4.0" />
         <import addon="script.skinvariables" version="1.0.0" />
         <import addon="script.texturemaker" version="0.2.8" />


### PR DESCRIPTION
Updated line 3 in addon.xml to 

`<import` addon="xbmc.gui" version="5.17.0" />

Should allow users on Omega to install and use Arctic Horizon 2 as per post on kodi forum by VelimirSaban.